### PR TITLE
Support file path logging in Evaluator

### DIFF
--- a/simpledspy/evaluator.py
+++ b/simpledspy/evaluator.py
@@ -20,9 +20,16 @@ class Evaluator:
         logger: Logger instance for recording evaluations
         evaluator_lm: Language model for evaluation
     """
-    def __init__(self, evaluation_instruction: str = "", log_file: str = "dspy_logs.jsonl"):
+    def __init__(self, evaluation_instruction: str = "",
+                 log_file: str = "dspy_logs.jsonl"):
+        """Initialize the evaluator.
+
+        Args:
+            evaluation_instruction: Instruction used when evaluating outputs.
+            log_file: Path to a JSONL file where evaluations will be logged.
+        """
         self.evaluation_instruction = evaluation_instruction
-        self.logger = Logger(log_file)
+        self.logger = Logger(log_file=log_file)
         self.evaluator_lm = dspy.LM(model="deepseek/deepseek-reasoner")
         dspy.configure(lm=self.evaluator_lm)
 

--- a/simpledspy/logger.py
+++ b/simpledspy/logger.py
@@ -7,7 +7,7 @@ Features:
 import json
 import time
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 class CustomJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder that converts non-serializable objects to strings"""
@@ -18,21 +18,44 @@ class CustomJSONEncoder(json.JSONEncoder):
             return str(o)
 
 class Logger:
-    """Handles logging of DSPy inputs and outputs per module"""
-    
-    def __init__(self, module_name: str, base_dir: str = ".simpledspy") -> None:
-        # Create base directory
-        self.base_dir = Path(base_dir) / "modules" / module_name
-        self.base_dir.mkdir(parents=True, exist_ok=True)
-        
-        # Create files for training and logged data
-        self.training_file = self.base_dir / "training.jsonl"
-        self.logged_file = self.base_dir / "logged.jsonl"
-        
-        # Create files if they don't exist
-        for file in [self.training_file, self.logged_file]:
-            if not file.exists():
-                file.touch()
+    """Handles logging of DSPy inputs and outputs."""
+
+    def __init__(self, module_name: Optional[str] = None,
+                 base_dir: str = ".simpledspy",
+                 log_file: Optional[str] = None) -> None:
+        """Create a new logger.
+
+        Args:
+            module_name: Name of the module to create a logging directory for.
+                Used when ``log_file`` is not provided.
+            base_dir: Base directory for module logs.
+            log_file: Optional direct path to a JSONL file. When provided, the
+                logger will write to this file instead of creating the
+                ``training.jsonl``/``logged.jsonl`` pair inside ``base_dir``.
+        """
+
+        if log_file:
+            # Logging directly to a specified file. Only ``logged_file`` is
+            # created and ``training_file`` is unused.
+            self.logged_file = Path(log_file)
+            self.logged_file.parent.mkdir(parents=True, exist_ok=True)
+            if not self.logged_file.exists():
+                self.logged_file.touch()
+            self.training_file = None
+        else:
+            # Default behaviour: create module specific directory with training
+            # and logged files.
+            if module_name is None:
+                raise ValueError("module_name is required when log_file is not set")
+            self.base_dir = Path(base_dir) / "modules" / module_name
+            self.base_dir.mkdir(parents=True, exist_ok=True)
+
+            self.training_file = self.base_dir / "training.jsonl"
+            self.logged_file = self.base_dir / "logged.jsonl"
+
+            for file in [self.training_file, self.logged_file]:
+                if not file.exists():
+                    file.touch()
 
     def log_to_section(self, data: Dict[str, Any], section: str = "logged") -> None:
         """Log a dictionary to the specified section


### PR DESCRIPTION
## Summary
- enhance `Logger` to optionally log to a direct file path
- update `Evaluator` to pass a log file path and document the new behaviour
- keep all existing functionality and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2b55b04883229f3a873330d61e51