### PR TITLE
Add setup_env.sh for dependency installation

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Setup script for simpledspy development environment
+# Creates a virtual environment and installs required dependencies.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${VENV_DIR:-.venv}"
+
+python3 -m venv "$VENV_DIR"
+# shellcheck disable=SC1090
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -e "$ROOT_DIR"
+# Install development dependencies
+pip install pytest black mypy twine
+
+echo "Environment setup complete. Activate with: source $VENV_DIR/bin/activate"


### PR DESCRIPTION
## Summary
- add a simple shell script to set up a virtual environment and install dependencies
- mark the script as executable

## Testing
- `./setup_env.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4365e8948322b0d81d6b33a8ba19