### PR TITLE
Add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest black
+      - name: Format check
+        run: black --check .
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
   <a href="https://github.com/psf/black">
     <img src="https://img.shields.io/static/v1?style=for-the-badge&label=Code%20Style&message=Black&color=black" alt="Code style: black">
   </a>
-  <a href="https://github.com/tomdoerr/simpledspy/actions/workflows/tests.yml">
-    <img src="https://img.shields.io/static/v1?style=for-the-badge&label=Tests&message=Passing&color=green" alt="Tests">
+  <a href="https://github.com/tomdoerr/simpledspy/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/static/v1?style=for-the-badge&label=CI&message=Passing&color=green" alt="CI">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run format and tests on Python 3.9, 3.10, 3.11
- update README badge to reference new workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b645f2fd4832287440268832dde3a